### PR TITLE
added basemap.at to tile map sources

### DIFF
--- a/site/tile_sources.xml
+++ b/site/tile_sources.xml
@@ -40,7 +40,7 @@
 
    <tile_source name="MTB Map CZ" url_template="http://tile.mtbmap.cz/mtbmap_tiles/{0}/{1}/{2}.png" ext=".png" min_zoom="7" max_zoom="16" tile_size="256" img_density="32" avg_img_size="18000"/>
 
-   <tile_source name="basemap.at" url_template="http://maps.wien.gv.at/basemap/geolandbasemap/normal/google3857/{0}/{2}/{1}.jpg" ext=".jpg" min_zoom="1" max_zoom="19" tile_size="256" img_density="16" avg_img_size="32000"/>
+   <tile_source name="basemap.at (AT)" url_template="http://maps.wien.gv.at/basemap/geolandbasemap/normal/google3857/{0}/{2}/{1}.jpg" ext=".jpg" min_zoom="1" max_zoom="19" tile_size="256" img_density="16" avg_img_size="32000"/>
 
    <tile_source name="Yandex RU" url_template="http://vec01.maps.yandex.net/tiles?l=map&amp;x={1}&amp;y={2}&amp;z={0}" ext=".jpg" min_zoom="1" max_zoom="18" tile_size="256" img_density="16" avg_img_size="18000" ellipsoid="true"/>
    <tile_source name="Top Yandex RU" url_template="http://vec01.maps.yandex.net/tiles?l=skl&amp;x={1}&amp;y={2}&amp;z={0}" ext=".jpg" min_zoom="1" max_zoom="18" tile_size="256" img_density="16" avg_img_size="18000" ellipsoid="true"/>


### PR DESCRIPTION
I've added http://www.basemap.at/, the Open Government  administrative map of Austria to the tile map sources. I've tested it via the user interface "add tile sources" and entered the values from the ".metainfo" file in "tile_sources.xml".
This has NOT been tested by building OsmAnd, please give it a try.

regards,

Toni

License conditions from the basemap site:
"basemap.at ist gemäß der Open Government Data Österreich Lizenz CC-BY 3.0 AT sowohl für private als auch kommerzielle Zwecke frei sowie entgeltfrei nutzbar." 
Translation (by me, so no guarantees): "basemap.at is according to Open Government Data Österreich License CC-BY 3.0 AT free for private and commercial use"
