### PR TITLE
Add OpenTopoMap to OsmAnd online maps

### DIFF
--- a/site/tile_sources.xml
+++ b/site/tile_sources.xml
@@ -94,6 +94,8 @@
   <tile_source name="Geofabrik.highways_eu" url_template="http://tools.geofabrik.de/osmi/tiles/highways/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="16" tile_size="256" img_density="16" avg_img_size="18000" />
 
   <tile_source name="OSM FR" url_template="http://a.tile.openstreetmap.fr/osmfr/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="20" tile_size="256" img_density="16" avg_img_size="18000"/>
+  
+  <tile_source name="OpenTopoMap" url_template="http://a.tile.opentopomap.org/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="15" tile_size="256" img_density="16" avg_img_size="56000"/>
 
 
 <!--


### PR DESCRIPTION
OpenTopoMap provides topographic maps for Europe, based on OpenStreetMap and SRTM. It somehow imitates "the old German map style".
I am the maintainer of opentopomap.org and grant mass downloads that are not too massive. Currently the server limits the download speed after a certain number of downloaded files.
