### PR TITLE
Take Wikimapia tiles back

### DIFF
--- a/site/tile_sources.xml
+++ b/site/tile_sources.xml
@@ -52,12 +52,11 @@
    <tile_source name="Yandex Satellite RU" url_template="https://sat01.maps.yandex.net/tiles?l=sat&amp;x={1}&amp;y={2}&amp;z={0}" ext=".jpg" min_zoom="1" max_zoom="16" tile_size="256" img_density="32" avg_img_size="18000" ellipsoid="true"/>
    <tile_source rule="yandex_traffic" name="Yandex Traffic RU"/>
 
-<!-- Does not work -->
-<!--   <tile_source rule="beanshell" name="Wikimapia" min_zoom="1" max_zoom="18" tile_size="256" img_density="16" avg_img_size="18000" ext="png"
-   url_template='String getTileUrl(int z, int x, int y) {  return "https://"+"i"+(x%4 + (y%4)*4)+".wikimapia.org/?x="+x+"&amp;y="+y+"&amp;zoom="+z;}'/>
+  <tile_source rule="beanshell" name="Wikimapia" min_zoom="1" max_zoom="18" tile_size="256" img_density="16" avg_img_size="18000" ext="png"
+   url_template='String getTileUrl(int z, int x, int y) {  return "http://"+"i"+(x%4 + (y%4)*4)+".wikimapia.org/?x="+x+"&amp;y="+y+"&amp;zoom="+z;}'/>
    
    <tile_source rule="beanshell" name="Top Wikimapia" min_zoom="1" max_zoom="18" tile_size="256" img_density="16" avg_img_size="18000" ext="png"
-   url_template='String getTileUrl(int z, int x, int y) {  return "https://"+"i"+(x%4 + (y%4)*4)+".wikimapia.org/?x="+x+"&amp;y="+y+"&amp;zoom="+z+"&amp;type=hybrid";}'/>-->
+   url_template='String getTileUrl(int z, int x, int y) {  return "http://"+"i"+(x%4 + (y%4)*4)+".wikimapia.org/?x="+x+"&amp;y="+y+"&amp;zoom="+z+"&amp;type=hybrid";}'/>
    
 
    <tile_source name="OpenFietskaart (NL)" url_template="http://overlay.openstreetmap.nl/openfietskaart-overlay/{0}/{1}/{2}.png" ext=".png" min_zoom="7" max_zoom="18" tile_size="256" img_density="16" avg_img_size="18000"/> 


### PR DESCRIPTION
@KOLANICH switched some URLs to HTTPS as well as Wikimapia ones at Jan 12 in 02b897b2dffaa96e06aa0779aad3a716b606d0bd . Looks like for WIkimapia it was a mistake because their CDN servers don't even listen on 443.  A day later @xmd5a2 8d811431638b7e5c2c685301db842706dead85d3 has commented out this URL's as not working. Looks like he did not notice they was broken by previous commit. I just checked them out in OsmAndMapCreator and they work just fine via http.